### PR TITLE
Fixed conflicting declaration

### DIFF
--- a/Seeed_HM330X.h
+++ b/Seeed_HM330X.h
@@ -44,7 +44,6 @@
                             }}while(0)
 
 typedef int s32;
-typedef long unsigned int u32;
 typedef unsigned char u8;
 typedef unsigned short u16;
 

--- a/Seeed_HM330X.h
+++ b/Seeed_HM330X.h
@@ -43,6 +43,9 @@
                             return a;   \
                             }}while(0)
 
+#if defined(__AVR__)
+typedef long unsigned int u32;
+#endif
 typedef int s32;
 typedef unsigned char u8;
 typedef unsigned short u16;


### PR DESCRIPTION
Updated u32 declaration.
Declaration only for AVR boards

Have such error, using it with ESP8266 board
```
In file included from .piolibdeps/test4/Grove - Laser PM2.5 Sensor HM3301_ID6306/Seeed_HM330X.cpp:32:0:
.piolibdeps/test4/Grove - Laser PM2.5 Sensor HM3301_ID6306/Seeed_HM330X.h:47:27: error: conflicting declaration 'typedef long unsigned int u32'
 typedef long unsigned int u32;
                           ^
In file included from /Users/.../.platformio/packages/framework-arduinoespressif8266/cores/esp8266/esp8266_peri.h:24:0,
                 from /Users/../.platformio/packages/framework-arduinoespressif8266/cores/esp8266/Arduino.h:38,
                 from .piolibdeps/test4/Grove - Laser PM2.5 Sensor HM3301_ID6306/Seeed_HM330X.h:35,
                 from .piolibdeps/test4/Grove - Laser PM2.5 Sensor HM3301_ID6306/Seeed_HM330X.cpp:32:
/Users/.../.platformio/packages/framework-arduinoespressif8266/tools/sdk/include/c_types.h:51:29: error: 'u32' has a previous declaration as 'typedef unsigned int u32'
 typedef unsigned int        u32;
```

If you accept this pull request, could you also release new version.