### PR TITLE
Fix duplicated definition of err_t

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+*.DS_Store

--- a/Seeed_HM330X.cpp
+++ b/Seeed_HM330X.cpp
@@ -38,23 +38,23 @@ HM330X::HM330X(u8 IIC_ADDR)
 }
 
 
-err_t HM330X::select_comm()
+HM330XErrorCode HM330X::select_comm()
 {
     return IIC_SEND_CMD(SELECT_COMM_CMD);
 }
 
-err_t HM330X::init()
+HM330XErrorCode HM330X::init()
 {
     Wire.begin();
-    err_t ret=NO_ERROR;
+    HM330XErrorCode ret;
     CHECK_RESULT(ret,select_comm());
     return ret;
 }
 
-err_t HM330X::read_sensor_value(u8 *data,u32 data_len)
+HM330XErrorCode HM330X::read_sensor_value(u8 *data,u32 data_len)
 {
     u32 time_out_count=0;
-    err_t ret=NO_ERROR;
+    HM330XErrorCode ret=NO_ERROR;
     Wire.requestFrom(0x40,29);
     while(data_len!=Wire.available())
     {
@@ -85,12 +85,13 @@ err_t HM330X::read_sensor_value(u8 *data,u32 data_len)
 /**********************************************************************************************************/
 
 
-/**@brief I2C write byte
+/**
+ * @brief I2C write byte
  * @param reg :Register address of operation object
  * @param byte :The byte to be wrote.
  * @return result of operation,non-zero if failed.
- * */
-err_t IIC_OPRTS::IIC_write_byte(u8 reg,u8 byte)
+ */
+HM330XErrorCode IIC_OPRTS::IIC_write_byte(u8 reg,u8 byte)
 {
     s32 ret=0;
     Wire.beginTransmission(_IIC_ADDR);
@@ -104,17 +105,18 @@ err_t IIC_OPRTS::IIC_write_byte(u8 reg,u8 byte)
 }
 
 
-/**@brief I2C write 16bit value
+/**
+ * @brief I2C write 16bit value
  * @param reg: Register address of operation object
  * @param value: The 16bit value to be wrote .
  * @return result of operation,non-zero if failed.
- * */
-err_t IIC_OPRTS::IIC_write_16bit(u8 reg,u16 value)
+ */
+HM330XErrorCode IIC_OPRTS::IIC_write_16bit(u8 reg,u16 value)
 {
     s32 ret=0;
     Wire.beginTransmission(_IIC_ADDR);
     Wire.write(reg);
-    
+
     Wire.write((u8)(value>>8));
     Wire.write((u8)value);
     ret=Wire.endTransmission();
@@ -126,14 +128,14 @@ err_t IIC_OPRTS::IIC_write_16bit(u8 reg,u16 value)
 
 
 
-/**@brief I2C read byte
+/**
+ * @brief I2C read byte
  * @param reg: Register address of operation object
  * @param byte: The byte to be read in.
  * @return result of operation,non-zero if failed.
- * */
-err_t IIC_OPRTS::IIC_read_byte(u8 reg,u8* byte)
+ */
+HM330XErrorCode IIC_OPRTS::IIC_read_byte(u8 reg,u8* byte)
 {
-    err_t ret=NO_ERROR;
     u32 time_out_count=0;
     Wire.beginTransmission(_IIC_ADDR);
     Wire.write(reg);
@@ -150,14 +152,14 @@ err_t IIC_OPRTS::IIC_read_byte(u8 reg,u8* byte)
     return NO_ERROR;
 }
 
-/**@brief I2C read 16bit value
+/**
+ * @brief I2C read 16bit value
  * @param reg: Register address of operation object
  * @param byte: The 16bit value to be read in.
  * @return result of operation,non-zero if failed.
- * */
-err_t IIC_OPRTS::IIC_read_16bit(u8 start_reg,u16 *value)
+ */
+HM330XErrorCode IIC_OPRTS::IIC_read_16bit(u8 start_reg,u16 *value)
 {
-    err_t ret=NO_ERROR;
     u32 time_out_count=0;
     u8 val=0;
     *value=0;
@@ -179,16 +181,16 @@ err_t IIC_OPRTS::IIC_read_16bit(u8 start_reg,u16 *value)
     return NO_ERROR;
 }
 
-
-/**@brief I2C read some bytes
+/**
+ * @brief I2C read some bytes
  * @param reg: Register address of operation object
  * @param data: The buf  to be read in.
  * @param data_len: The length of buf need to read in.
  * @return result of operation,non-zero if failed.
- * */
-err_t IIC_OPRTS::IIC_read_bytes(u8 start_reg,u8 *data,u32 data_len)
+ */
+HM330XErrorCode IIC_OPRTS::IIC_read_bytes(u8 start_reg,u8 *data,u32 data_len)
 {
-    err_t ret=NO_ERROR;
+    HM330XErrorCode ret=NO_ERROR;
     u32 time_out_count=0;
     Wire.beginTransmission(_IIC_ADDR);
     Wire.write(start_reg);
@@ -201,7 +203,7 @@ err_t IIC_OPRTS::IIC_read_bytes(u8 start_reg,u8 *data,u32 data_len)
         if(time_out_count>10)  return ERROR_COMM;
         delay(1);
     }
-    
+
     for(int i=0;i<data_len;i++)
     {
         data[i]=Wire.read();
@@ -210,16 +212,17 @@ err_t IIC_OPRTS::IIC_read_bytes(u8 start_reg,u8 *data,u32 data_len)
 }
 
 
-/**@brief change the I2C address from default.
- * @param IIC_ADDR: I2C address to be set 
- * */
+/**
+ * @brief change the I2C address from default.
+ * @param IIC_ADDR: I2C address to be set
+ */
 void IIC_OPRTS::set_iic_addr(u8 IIC_ADDR)
 {
     _IIC_ADDR=IIC_ADDR;
 }
 
 
-err_t IIC_OPRTS::IIC_SEND_CMD(u8 CMD)
+HM330XErrorCode IIC_OPRTS::IIC_SEND_CMD(u8 CMD)
 {
     int ret=0;
     Wire.beginTransmission(_IIC_ADDR);

--- a/Seeed_HM330X.h
+++ b/Seeed_HM330X.h
@@ -62,34 +62,34 @@ typedef enum
     ERROR_PARAM=-1,
     ERROR_COMM =-2,
     ERROR_OTHERS=-128,
-}err_t;
+} HM330XErrorCode;
 
 class IIC_OPRTS
 {
-    public:
-        
-        err_t IIC_write_byte(u8 reg,u8 byte);
-        err_t IIC_read_byte(u8 reg,u8* byte);
-        void set_iic_addr(u8 IIC_ADDR);
-        err_t IIC_read_16bit(u8 start_reg,u16 *value);
-        err_t IIC_write_16bit(u8 reg,u16 value);
+public:
 
-        err_t IIC_read_bytes(u8 start_reg,u8 *data,u32 data_len);
+    HM330XErrorCode IIC_write_byte(u8 reg,u8 byte);
+    HM330XErrorCode IIC_read_byte(u8 reg,u8* byte);
+    void set_iic_addr(u8 IIC_ADDR);
+    HM330XErrorCode IIC_read_16bit(u8 start_reg,u16 *value);
+    HM330XErrorCode IIC_write_16bit(u8 reg,u16 value);
 
-        err_t IIC_SEND_CMD(u8 CMD);
-        
-    private:
-        u8 _IIC_ADDR;
+    HM330XErrorCode IIC_read_bytes(u8 start_reg,u8 *data,u32 data_len);
+
+    HM330XErrorCode IIC_SEND_CMD(u8 CMD);
+
+private:
+    u8 _IIC_ADDR;
 };
 
 class HM330X:public IIC_OPRTS
 {
-    public:
-        HM330X(u8 IIC_ADDR=DEFAULT_IIC_ADDR);
-        err_t init();
-        err_t select_comm();
-        err_t read_sensor_value(u8 *data,u32 data_len);
-    private:
+public:
+    HM330X(u8 IIC_ADDR=DEFAULT_IIC_ADDR);
+    HM330XErrorCode init();
+    HM330XErrorCode select_comm();
+    HM330XErrorCode read_sensor_value(u8 *data,u32 data_len);
+private:
 
 };
 

--- a/examples/basic_demo/basic_demo.ino
+++ b/examples/basic_demo/basic_demo.ino
@@ -1,7 +1,7 @@
 /*
  * basic_demo.ino
  * Example for Seeed PM2.5 Sensor(HM300)
- *  
+ *
  * Copyright (c) 2018 Seeed Technology Co., Ltd.
  * Website    : www.seeed.cc
  * Author     : downey
@@ -32,9 +32,9 @@
 #include "Seeed_HM330X.h"
 
 #ifdef  ARDUINO_SAMD_VARIANT_COMPLIANCE
-  #define SERIAL SerialUSB
+#define SERIAL_OUTPUT SerialUSB
 #else
-  #define SERIAL Serial
+#define SERIAL_OUTPUT Serial
 #endif
 
 
@@ -43,48 +43,49 @@ u8 buf[30];
 
 
 const char *str[]={"sensor num: ","PM1.0 concentration(CF=1,Standard particulate matter,unit:ug/m3): ",
-                    "PM2.5 concentration(CF=1,Standard particulate matter,unit:ug/m3): ",
-                    "PM10 concentration(CF=1,Standard particulate matter,unit:ug/m3): ",
-                    "PM1.0 concentration(Atmospheric environment,unit:ug/m3): ",
-                    "PM2.5 concentration(Atmospheric environment,unit:ug/m3): ",
-                    "PM10 concentration(Atmospheric environment,unit:ug/m3): ",
-                    };
+                   "PM2.5 concentration(CF=1,Standard particulate matter,unit:ug/m3): ",
+                   "PM10 concentration(CF=1,Standard particulate matter,unit:ug/m3): ",
+                   "PM1.0 concentration(Atmospheric environment,unit:ug/m3): ",
+                   "PM2.5 concentration(Atmospheric environment,unit:ug/m3): ",
+                   "PM10 concentration(Atmospheric environment,unit:ug/m3): ",
+};
 
-err_t print_result(const char* str,u16 value)
+HM330XErrorCode print_result(const char* str,u16 value)
 {
     if(NULL==str)
         return ERROR_PARAM;
-    SERIAL.print(str);
-    SERIAL.println(value);
+    SERIAL_OUTPUT.print(str);
+    SERIAL_OUTPUT.println(value);
     return NO_ERROR;
 }
 
 /*parse buf with 29 u8-data*/
-err_t parse_result(u8 *data)
+HM330XErrorCode parse_result(u8 *data)
 {
     u16 value=0;
-    err_t NO_ERROR;
     if(NULL==data)
         return ERROR_PARAM;
     for(int i=1;i<8;i++)
     {
-         value = (u16)data[i*2]<<8|data[i*2+1];
-         print_result(str[i-1],value);
+        value = (u16)data[i*2]<<8|data[i*2+1];
+        print_result(str[i-1],value);
 
     }
+
+    return NO_ERROR;
 }
 
-err_t parse_result_value(u8 *data)
+HM330XErrorCode parse_result_value(u8 *data)
 {
     if(NULL==data)
         return ERROR_PARAM;
     for(int i=0;i<28;i++)
     {
-        SERIAL.print(data[i],HEX);
-        SERIAL.print("  ");
+        SERIAL_OUTPUT.print(data[i],HEX);
+        SERIAL_OUTPUT.print("  ");
         if((0==(i)%5)||(0==i))
         {
-            SERIAL.println(" ");
+            SERIAL_OUTPUT.println(" ");
         }
     }
     u8 sum=0;
@@ -94,10 +95,10 @@ err_t parse_result_value(u8 *data)
     }
     if(sum!=data[28])
     {
-        SERIAL.println("wrong checkSum!!!!");
+        SERIAL_OUTPUT.println("wrong checkSum!!!!");
     }
-    SERIAL.println(" ");
-    SERIAL.println(" ");
+    SERIAL_OUTPUT.println(" ");
+    SERIAL_OUTPUT.println(" ");
     return NO_ERROR;
 }
 
@@ -105,15 +106,15 @@ err_t parse_result_value(u8 *data)
 /*30s*/
 void setup()
 {
-    SERIAL.begin(115200);
+    SERIAL_OUTPUT.begin(115200);
     delay(100);
-    SERIAL.println("Serial start");
+    SERIAL_OUTPUT.println("Serial start");
     if(sensor.init())
     {
-        SERIAL.println("HM330X init failed!!!");
+        SERIAL_OUTPUT.println("HM330X init failed!!!");
         while(1);
     }
-    
+
 }
 
 
@@ -122,13 +123,12 @@ void loop()
 {
     if(sensor.read_sensor_value(buf,29))
     {
-        SERIAL.println("HM330X read result failed!!!");
+        SERIAL_OUTPUT.println("HM330X read result failed!!!");
     }
     parse_result_value(buf);
     parse_result(buf);
-    SERIAL.println(" ");
-    SERIAL.println(" ");
-    SERIAL.println(" ");
+    SERIAL_OUTPUT.println(" ");
+    SERIAL_OUTPUT.println(" ");
+    SERIAL_OUTPUT.println(" ");
     delay(5000);
 }
-

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Grove - Laser PM2.5 Sensor HM3301
-version=1.0.1
+version=1.0.2
 author=Seeed Studio
 maintainer=Seeed Studio <techsupport@seeed.cc>
 sentence=Arduino library to control PM2.5 sensor(HM3300).


### PR DESCRIPTION
Fixed duplicated err_t definition, changed type name to more understandable

* renamed err_t to HM330XErrorCode
* added gitignore
* renamed SERIAL to SERIAL_OUTPUT (due to already defined SERIAL in Arduino.h)
   ```.platformio/packages/framework-arduinoespressif8266/cores/esp8266/Arduino.h:70:0: note: this is the location of the previous definition```
* removed unused variables
* updated version